### PR TITLE
Feature: Skip double formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,23 @@ A [NumberFormat](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/ja
 
 </td>
 </tr>
+<tr>
+<td>
+
+`skipDoubleFormatting`
+
+</td>
+<td>
+
+Allows for suppressing double formatting
+
+</td>
+<td>
+
+`false`
+
+</td>
+</tr>
 
 <tr>
 <td>
@@ -691,6 +708,8 @@ elements in RDF lists.
 \* Adapted from [EditorConfig](https://editorconfig.org/#file-format-details)
 
 ## Release Notes
+* 1.2.13: 
+  * Feature: Skip double formatting
 * 1.2.12:
   * Bugfix: Handle RDF lists that start with a non-anonymous node
   * Bugfix: Handle blank node cycles

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ One of `LATIN1`, `UTF_16_BE`, `UTF_16_LE`, `UTF_8`, `UTF_8_BOM`
 </td>
 <td>
 
-A [NumberFormat](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/NumberFormat.html) that describes how `xsd:double` literals are formatted
+A [NumberFormat](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/NumberFormat.html) that describes how `xsd:double` literals are formatted if `enableDoubleFormatting` is `true`.
 
 </td>
 <td>
@@ -314,12 +314,12 @@ A [NumberFormat](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/ja
 <tr>
 <td>
 
-`skipDoubleFormatting`
+`enableDoubleFormatting`
 
 </td>
 <td>
 
-Allows for suppressing double formatting
+Enables formatting of `xsd:double` values (see `doubleFormat` option)
 
 </td>
 <td>

--- a/src/main/java/de/atextor/turtle/formatter/FormattingStyle.java
+++ b/src/main/java/de/atextor/turtle/formatter/FormattingStyle.java
@@ -107,6 +107,9 @@ public class FormattingStyle {
     public NumberFormat doubleFormat = new DecimalFormat("0.####E0" , DecimalFormatSymbols.getInstance(Locale.US));
 
     @Builder.Default
+    public boolean skipDoubleFormatting = true;
+
+    @Builder.Default
     public EndOfLineStyle endOfLine = EndOfLineStyle.LF;
 
     @Builder.Default

--- a/src/main/java/de/atextor/turtle/formatter/FormattingStyle.java
+++ b/src/main/java/de/atextor/turtle/formatter/FormattingStyle.java
@@ -107,7 +107,7 @@ public class FormattingStyle {
     public NumberFormat doubleFormat = new DecimalFormat("0.####E0" , DecimalFormatSymbols.getInstance(Locale.US));
 
     @Builder.Default
-    public boolean skipDoubleFormatting = true;
+    public boolean enableDoubleFormatting = false;
 
     @Builder.Default
     public EndOfLineStyle endOfLine = EndOfLineStyle.LF;

--- a/src/main/java/de/atextor/turtle/formatter/TurtleFormatter.java
+++ b/src/main/java/de/atextor/turtle/formatter/TurtleFormatter.java
@@ -626,8 +626,12 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
 
     private State writeLiteral( final Literal literal, final State state ) {
         String datatypeUri = literal.getDatatypeURI();
-        if (style.skipDoubleFormatting && datatypeUri.equals(XSD.xdouble.getURI())){
+        if (datatypeUri.equals(XSD.xdouble.getURI())) {
+            if (style.enableDoubleFormatting){
+                return state.write(style.doubleFormat.format(literal.getDouble()));
+            } else {
                 return state.write(literal.getLexicalForm());
+            }
         } else {
             if (datatypeUri.equals(XSD.xboolean.getURI())) {
                 return state.write(literal.getBoolean() ? "true" : "false");
@@ -640,9 +644,6 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
             }
             if (datatypeUri.equals(XSD.integer.getURI())) {
                 return state.write(literal.getValue().toString());
-            }
-            if (datatypeUri.equals(XSD.xdouble.getURI())) {
-                return state.write(style.doubleFormat.format(literal.getDouble()));
             }
             if (datatypeUri.equals(RDF.langString.getURI())) {
                 return state.write(quoteAndEscape(literal) + "@" + literal.getLanguage());

--- a/src/main/java/de/atextor/turtle/formatter/TurtleFormatter.java
+++ b/src/main/java/de/atextor/turtle/formatter/TurtleFormatter.java
@@ -632,25 +632,24 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
             } else {
                 return state.write(literal.getLexicalForm());
             }
-        } else {
-            if (datatypeUri.equals(XSD.xboolean.getURI())) {
-                return state.write(literal.getBoolean() ? "true" : "false");
-            }
-            if (datatypeUri.equals(XSD.xstring.getURI())) {
-                return state.write(quoteAndEscape(literal));
-            }
-            if (datatypeUri.equals(XSD.decimal.getURI())) {
-                return state.write(literal.getLexicalForm());
-            }
-            if (datatypeUri.equals(XSD.integer.getURI())) {
-                return state.write(literal.getValue().toString());
-            }
-            if (datatypeUri.equals(RDF.langString.getURI())) {
-                return state.write(quoteAndEscape(literal) + "@" + literal.getLanguage());
-            }
+        }
+        if (datatypeUri.equals(XSD.xboolean.getURI())) {
+            return state.write(literal.getBoolean() ? "true" : "false");
+        }
+        if (datatypeUri.equals(XSD.xstring.getURI())) {
+            return state.write(quoteAndEscape(literal));
+        }
+        if (datatypeUri.equals(XSD.decimal.getURI())) {
+            return state.write(literal.getLexicalForm());
+        }
+        if (datatypeUri.equals(XSD.integer.getURI())) {
+            return state.write(literal.getValue().toString());
+        }
+        if (datatypeUri.equals(RDF.langString.getURI())) {
+            return state.write(quoteAndEscape(literal) + "@" + literal.getLanguage());
         }
 
-        final Resource typeResource = ResourceFactory.createResource( literal.getDatatypeURI() );
+        final Resource typeResource = ResourceFactory.createResource( datatypeUri );
         final State literalWritten = state.write( quoteAndEscape( literal ) + "^^" );
         return writeUriResource( typeResource, literalWritten );
     }
@@ -960,17 +959,5 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
             }
             return withLastCharacter( end ).withAlignment( alignment + content.length() );
         }
-    }
-
-    public static void main(String[] args) throws IOException {
-        System.out.println(Arrays.stream(args).collect(Collectors.joining("\n")));
-        if (args.length != 1){
-            throw new IllegalArgumentException("usage: TurtleFormatter <file>");
-        }
-        String filename = args[0];
-        String content = Files.readString(Path.of(filename), StandardCharsets.UTF_8);
-        final FormattingStyle style = FormattingStyle.builder().alignPredicates(true).alignObjects(true).build();
-        final TurtleFormatter formatter = new TurtleFormatter(style);
-        System.out.println(formatter.applyToContent(content));
     }
 }

--- a/src/main/java/de/atextor/turtle/formatter/TurtleFormatter.java
+++ b/src/main/java/de/atextor/turtle/formatter/TurtleFormatter.java
@@ -31,6 +31,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -622,23 +625,28 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
     }
 
     private State writeLiteral( final Literal literal, final State state ) {
-        if ( literal.getDatatypeURI().equals( XSD.xboolean.getURI() ) ) {
-            return state.write( literal.getBoolean() ? "true" : "false" );
-        }
-        if ( literal.getDatatypeURI().equals( XSD.xstring.getURI() ) ) {
-            return state.write( quoteAndEscape( literal ) );
-        }
-        if ( literal.getDatatypeURI().equals( XSD.decimal.getURI() ) ) {
-            return state.write( literal.getLexicalForm() );
-        }
-        if ( literal.getDatatypeURI().equals( XSD.integer.getURI() ) ) {
-            return state.write( literal.getValue().toString() );
-        }
-        if ( literal.getDatatypeURI().equals( XSD.xdouble.getURI() ) ) {
-            return state.write( style.doubleFormat.format( literal.getDouble() ) );
-        }
-        if ( literal.getDatatypeURI().equals( RDF.langString.getURI() ) ) {
-            return state.write( quoteAndEscape( literal ) + "@" + literal.getLanguage() );
+        String datatypeUri = literal.getDatatypeURI();
+        if (style.skipDoubleFormatting && datatypeUri.equals(XSD.xdouble.getURI())){
+                return state.write(literal.getLexicalForm());
+        } else {
+            if (datatypeUri.equals(XSD.xboolean.getURI())) {
+                return state.write(literal.getBoolean() ? "true" : "false");
+            }
+            if (datatypeUri.equals(XSD.xstring.getURI())) {
+                return state.write(quoteAndEscape(literal));
+            }
+            if (datatypeUri.equals(XSD.decimal.getURI())) {
+                return state.write(literal.getLexicalForm());
+            }
+            if (datatypeUri.equals(XSD.integer.getURI())) {
+                return state.write(literal.getValue().toString());
+            }
+            if (datatypeUri.equals(XSD.xdouble.getURI())) {
+                return state.write(style.doubleFormat.format(literal.getDouble()));
+            }
+            if (datatypeUri.equals(RDF.langString.getURI())) {
+                return state.write(quoteAndEscape(literal) + "@" + literal.getLanguage());
+            }
         }
 
         final Resource typeResource = ResourceFactory.createResource( literal.getDatatypeURI() );
@@ -951,5 +959,17 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
             }
             return withLastCharacter( end ).withAlignment( alignment + content.length() );
         }
+    }
+
+    public static void main(String[] args) throws IOException {
+        System.out.println(Arrays.stream(args).collect(Collectors.joining("\n")));
+        if (args.length != 1){
+            throw new IllegalArgumentException("usage: TurtleFormatter <file>");
+        }
+        String filename = args[0];
+        String content = Files.readString(Path.of(filename), StandardCharsets.UTF_8);
+        final FormattingStyle style = FormattingStyle.builder().alignPredicates(true).alignObjects(true).build();
+        final TurtleFormatter formatter = new TurtleFormatter(style);
+        System.out.println(formatter.applyToContent(content));
     }
 }

--- a/src/test/java/de/atextor/turtle/formatter/TurtleFormatterTest.java
+++ b/src/test/java/de/atextor/turtle/formatter/TurtleFormatterTest.java
@@ -1,25 +1,13 @@
 package de.atextor.turtle.formatter;
 
-import org.apache.jena.atlas.io.AWriter;
-import org.apache.jena.atlas.io.IO;
-import org.apache.jena.graph.Graph;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.RDFParser;
-import org.apache.jena.riot.lang.LabelToNode;
-import org.apache.jena.riot.out.NodeFormatter;
-import org.apache.jena.riot.out.NodeFormatterNT;
-import org.apache.jena.riot.system.StreamRDF;
-import org.apache.jena.riot.system.StreamRDFOps;
-import org.apache.jena.riot.writer.StreamWriterTriX;
-import org.apache.jena.riot.writer.WriterStreamRDFPlain;
+import org.apache.jena.rdf.model.impl.PropertyImpl;
 import org.apache.jena.vocabulary.RDF;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -28,7 +16,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -1032,6 +1019,22 @@ public class TurtleFormatterTest {
         }
     }
 
+    @Test
+    public void testSkipFormattingValueOfPredicate() {
+        final String modelString = """
+                       @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+                       @prefix ex: <http://example.com/ns#> .
+                        
+                       ex:something ex:decimalProp 0.0000000006241509074460762607776240980930446 ;
+                         ex:doubleProp 6.241509074460762607776240980930446E-10 .""";
+
+        final FormattingStyle style = FormattingStyle.builder().skipDoubleFormatting(true).build();
+
+        final TurtleFormatter formatter = new TurtleFormatter( style );
+        final String result = formatter.applyToContent( modelString );
+        assertThat(result.trim()).isEqualTo(modelString);
+    }
+
     private Model modelFromString( final String content ) {
         final Model model = ModelFactory.createDefaultModel();
         final InputStream stream = new ByteArrayInputStream( content.getBytes( StandardCharsets.UTF_8 ) );
@@ -1047,4 +1050,6 @@ public class TurtleFormatterTest {
         model.setNsPrefix( "abcdef", "http://example.com/abc" );
         return model;
     }
+
+
 }

--- a/src/test/java/de/atextor/turtle/formatter/TurtleFormatterTest.java
+++ b/src/test/java/de/atextor/turtle/formatter/TurtleFormatterTest.java
@@ -1035,6 +1035,38 @@ public class TurtleFormatterTest {
         assertThat(result.trim()).isEqualTo(modelString);
     }
 
+    @Test
+    public void testDoubleFormatDefault() {
+        final String modelString = """
+                       @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+                       @prefix ex: <http://example.com/ns#> .
+                        
+                       ex:something ex:decimalProp 0.0000000006241509074460762607776240980930446 ;
+                         ex:doubleProp 6.241509074460762607776240980930446E-10 .""";
+
+        final FormattingStyle style = FormattingStyle.builder().build();
+
+        final TurtleFormatter formatter = new TurtleFormatter( style );
+        final String result = formatter.applyToContent( modelString );
+        assertThat(result.trim()).isEqualTo(modelString);
+    }
+
+    @Test
+    public void testDoubleFormat() {
+        final String modelString = """
+                       @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+                       @prefix ex: <http://example.com/ns#> .
+                        
+                       ex:something ex:decimalProp 0.0000000006241509074460762607776240980930446 ;
+                         ex:doubleProp 6.2415E-10 .""";
+
+        final FormattingStyle style = FormattingStyle.builder().skipDoubleFormatting(false).build();
+
+        final TurtleFormatter formatter = new TurtleFormatter( style );
+        final String result = formatter.applyToContent( modelString );
+        assertThat(result.trim()).isEqualTo(modelString);
+    }
+
     private Model modelFromString( final String content ) {
         final Model model = ModelFactory.createDefaultModel();
         final InputStream stream = new ByteArrayInputStream( content.getBytes( StandardCharsets.UTF_8 ) );

--- a/src/test/java/de/atextor/turtle/formatter/TurtleFormatterTest.java
+++ b/src/test/java/de/atextor/turtle/formatter/TurtleFormatterTest.java
@@ -6,7 +6,6 @@ import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.rdf.model.impl.PropertyImpl;
 import org.apache.jena.vocabulary.RDF;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -1020,7 +1019,7 @@ public class TurtleFormatterTest {
     }
 
     @Test
-    public void testSkipFormattingValueOfPredicate() {
+    public void testEnableDoubleFormatting() {
         final String modelString = """
                        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
                        @prefix ex: <http://example.com/ns#> .
@@ -1028,7 +1027,7 @@ public class TurtleFormatterTest {
                        ex:something ex:decimalProp 0.0000000006241509074460762607776240980930446 ;
                          ex:doubleProp 6.241509074460762607776240980930446E-10 .""";
 
-        final FormattingStyle style = FormattingStyle.builder().skipDoubleFormatting(true).build();
+        final FormattingStyle style = FormattingStyle.builder().enableDoubleFormatting(false).build();
 
         final TurtleFormatter formatter = new TurtleFormatter( style );
         final String result = formatter.applyToContent( modelString );
@@ -1036,7 +1035,7 @@ public class TurtleFormatterTest {
     }
 
     @Test
-    public void testDoubleFormatDefault() {
+    public void testDoubleFormattingDefault() {
         final String modelString = """
                        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
                        @prefix ex: <http://example.com/ns#> .
@@ -1052,7 +1051,7 @@ public class TurtleFormatterTest {
     }
 
     @Test
-    public void testDoubleFormat() {
+    public void testDisableDoubleFormatting() {
         final String modelString = """
                        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
                        @prefix ex: <http://example.com/ns#> .
@@ -1060,7 +1059,7 @@ public class TurtleFormatterTest {
                        ex:something ex:decimalProp 0.0000000006241509074460762607776240980930446 ;
                          ex:doubleProp 6.2415E-10 .""";
 
-        final FormattingStyle style = FormattingStyle.builder().skipDoubleFormatting(false).build();
+        final FormattingStyle style = FormattingStyle.builder().enableDoubleFormatting(true).build();
 
         final TurtleFormatter formatter = new TurtleFormatter( style );
         final String result = formatter.applyToContent( modelString );


### PR DESCRIPTION
Provides a new style property, `skipDoubleFormatting` (default `true`) that causes all double values to be formatted as they are in the input.

(also adds a main method to the TurtleFormatter for easy testing)

closes #30 