### PR TITLE
Fix leading zeros in integer literals

### DIFF
--- a/src/main/java/de/atextor/turtle/formatter/TurtleFormatter.java
+++ b/src/main/java/de/atextor/turtle/formatter/TurtleFormatter.java
@@ -640,7 +640,7 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
             return state.write( literal.getLexicalForm() );
         }
         if ( datatypeUri.equals( XSD.integer.getURI() ) ) {
-            return state.write( literal.getValue().toString() );
+            return state.write( literal.getLexicalForm() );
         }
         if ( datatypeUri.equals( RDF.langString.getURI() ) ) {
             return state.write( quoteAndEscape( literal ) + "@" + literal.getLanguage() );

--- a/src/test/java/de/atextor/turtle/formatter/TurtleFormatterTest.java
+++ b/src/test/java/de/atextor/turtle/formatter/TurtleFormatterTest.java
@@ -1066,6 +1066,24 @@ public class TurtleFormatterTest {
         assertThat(result.trim()).isEqualTo(modelString);
     }
 
+    @Test
+    public void testIntegerLiteralWithLeadingZeros(){
+        String content =   """
+           @prefix : <http://example.com/ns#> .
+           :thing :value 060.
+           
+           """;
+        String expected = """
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+            @prefix : <http://example.com/ns#> .
+            
+            :thing :value 060 .""";
+        final FormattingStyle style = FormattingStyle.DEFAULT;
+        final TurtleFormatter formatter = new TurtleFormatter(style);
+        final String result = formatter.applyToContent(content);
+        assertThat(result.trim()).isEqualTo(expected);
+    }
+
     private Model modelFromString( final String content ) {
         final Model model = ModelFactory.createDefaultModel();
         final InputStream stream = new ByteArrayInputStream( content.getBytes( StandardCharsets.UTF_8 ) );


### PR DESCRIPTION
The formatter used to swallow leading zeros in integer literals, as in the triple,

```
:thing :value 060 .
```

With this change, by rendering the lexical form of the literal, the exact input form is reproduced.

Fixes #35 