### PR TITLE
Fix numeric literal formatting

### DIFF
--- a/src/main/java/de/atextor/turtle/formatter/TurtleFormatter.java
+++ b/src/main/java/de/atextor/turtle/formatter/TurtleFormatter.java
@@ -54,6 +54,10 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
 
     private static final Logger LOG = LoggerFactory.getLogger( TurtleFormatter.class );
 
+    private static final Pattern XSD_DECIMAL_UNQUOTED_REGEX = Pattern.compile("[+-]?\\d*\\.\\d+");
+
+    private static final Pattern XSD_DOUBLE_UNQUOTED_REGEX = Pattern.compile("(([+-]?\\d+\\.\\d+)|([+-]?\\.\\d+)|([+-]?\\d+))[eE][+-]?\\d+");
+
     /**
      * String escape sequences as described in <a href="https://www.w3.org/TR/turtle/#sec-escapes">Escape Sequences</a>.
      * <p>
@@ -626,7 +630,8 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
         if ( datatypeUri.equals( XSD.xdouble.getURI() ) ) {
             if ( style.enableDoubleFormatting ) {
                 return state.write( style.doubleFormat.format( literal.getDouble() ) );
-            } else {
+            } else if (XSD_DOUBLE_UNQUOTED_REGEX.matcher(literal.getLexicalForm()).matches()) {
+                // only use unquoted form if it will be parsed as an xsd:double
                 return state.write( literal.getLexicalForm() );
             }
         }
@@ -637,7 +642,10 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
             return state.write( quoteAndEscape( literal ) );
         }
         if ( datatypeUri.equals( XSD.decimal.getURI() ) ) {
-            return state.write( literal.getLexicalForm() );
+            if (XSD_DECIMAL_UNQUOTED_REGEX.matcher(literal.getLexicalForm()).matches()) {
+                // only use unquoted form if it will be parsed as an xsd:decimal
+                return state.write(literal.getLexicalForm());
+            }
         }
         if ( datatypeUri.equals( XSD.integer.getURI() ) ) {
             return state.write( literal.getLexicalForm() );

--- a/src/test/java/de/atextor/turtle/formatter/TurtleFormatterTest.java
+++ b/src/test/java/de/atextor/turtle/formatter/TurtleFormatterTest.java
@@ -1084,6 +1084,79 @@ public class TurtleFormatterTest {
         assertThat(result.trim()).isEqualTo(expected);
     }
 
+    @Test
+    public void testDoubleLiteralWithoutFractions(){
+        String content =   """
+           @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+           @prefix : <http://example.com/ns#> .
+           :thing :value "40"^^xsd:double.
+           """;
+        String expected = """
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+            @prefix : <http://example.com/ns#> .
+            
+            :thing :value "40"^^xsd:double .""";
+        final FormattingStyle style = FormattingStyle.DEFAULT;
+        final TurtleFormatter formatter = new TurtleFormatter(style);
+        final String result = formatter.applyToContent(content);
+        assertThat(result.trim()).isEqualTo(expected);
+    }
+
+    @Test
+    public void testDoubleLiteralWithFractions(){
+        String content =   """
+           @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+           @prefix : <http://example.com/ns#> .
+           :thing :value "4.001E2"^^xsd:double.
+           """;
+        String expected = """
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+            @prefix : <http://example.com/ns#> .
+            
+            :thing :value 4.001E2 .""";
+        final FormattingStyle style = FormattingStyle.DEFAULT;
+        final TurtleFormatter formatter = new TurtleFormatter(style);
+        final String result = formatter.applyToContent(content);
+        assertThat(result.trim()).isEqualTo(expected);
+    }
+
+    @Test
+    public void testDecimalLiteralWithoutFractions(){
+        String content =   """
+           @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+           @prefix : <http://example.com/ns#> .
+           :thing :value "40"^^xsd:decimal.
+           """;
+        String expected = """
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+            @prefix : <http://example.com/ns#> .
+            
+            :thing :value "40"^^xsd:decimal .""";
+        final FormattingStyle style = FormattingStyle.DEFAULT;
+        final TurtleFormatter formatter = new TurtleFormatter(style);
+        final String result = formatter.applyToContent(content);
+        assertThat(result.trim()).isEqualTo(expected);
+    }
+
+    @Test
+    public void testDecimalLiteralWithFractions(){
+        String content =   """
+           @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+           @prefix : <http://example.com/ns#> .
+           :thing :value "40.0001"^^xsd:decimal.
+           """;
+        String expected = """
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+            @prefix : <http://example.com/ns#> .
+            
+            :thing :value 40.0001 .""";
+        final FormattingStyle style = FormattingStyle.DEFAULT;
+        final TurtleFormatter formatter = new TurtleFormatter(style);
+        final String result = formatter.applyToContent(content);
+        assertThat(result.trim()).isEqualTo(expected);
+    }
+
+
     private Model modelFromString( final String content ) {
         final Model model = ModelFactory.createDefaultModel();
         final InputStream stream = new ByteArrayInputStream( content.getBytes( StandardCharsets.UTF_8 ) );


### PR DESCRIPTION
Prior to this commit, in some situations, formatting changes the datatype of numeric literals (xsd:double and xsd:decimal). The change happens if the lexical form is ambiguous because it does not include a fractional part.

This commit checks for this condition and uses the quoted form in these cases.

Fixes #39 