### PR TITLE
Fix list formatting problem

### DIFF
--- a/src/main/java/de/atextor/turtle/formatter/TurtleFormatter.java
+++ b/src/main/java/de/atextor/turtle/formatter/TurtleFormatter.java
@@ -468,8 +468,20 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
     }
 
     private boolean isList( final RDFNode node, final State state ) {
-        return node.equals( RDF.nil ) ||
-            ( node.isAnon() && state.model.contains( node.asResource(), RDF.rest, (RDFNode) null ) );
+        if (!node.isResource()){
+            return false;
+        }
+        boolean listNodeHasAdditionalTriples = state.model.listStatements(node.asResource(), null, (RDFNode) null)
+                .toList()
+                .stream()
+                .map(Statement::getPredicate)
+                .filter(p -> ! p.equals(RDF.first))
+                .anyMatch(p -> ! p.equals(RDF.rest));
+        if (listNodeHasAdditionalTriples){
+            return false;
+        }
+        return ( node.isAnon()
+                        && state.model.contains( node.asResource(), RDF.rest, (RDFNode) null ) );
     }
 
     private State writeResource( final Resource resource, final State state ) {

--- a/src/test/java/de/atextor/turtle/formatter/TurtleFormatterTest.java
+++ b/src/test/java/de/atextor/turtle/formatter/TurtleFormatterTest.java
@@ -1157,6 +1157,38 @@ public class TurtleFormatterTest {
     }
 
 
+    @Test
+    public void testListNodeWithAdditionalTriples(){
+        String content = """
+            @prefix : <http://example.com/ns#> .
+            @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            :thing :hasList  [
+                a :SomeListClass ;
+                a rdf:List ;
+                :comment "a very special list";
+                rdf:first 1 ;
+                rdf:rest ( 2 3 4 );
+            ] .
+            """;
+        String expected = """
+           @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+           @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+           @prefix : <http://example.com/ns#> .
+        
+           :thing :hasList [
+               a :SomeListClass, rdf:List ;
+               :comment "a very special list" ;
+               rdf:first 1 ;
+               rdf:rest ( 2 3 4 ) ;
+             ] .""";
+        final FormattingStyle style = FormattingStyle.DEFAULT;
+        final TurtleFormatter formatter = new TurtleFormatter(style);
+        final String result = formatter.applyToContent(content);
+        assertThat(result.trim()).isEqualTo(expected);
+    }
+
+
+
     private Model modelFromString( final String content ) {
         final Model model = ModelFactory.createDefaultModel();
         final InputStream stream = new ByteArrayInputStream( content.getBytes( StandardCharsets.UTF_8 ) );


### PR DESCRIPTION
Situation before this commit: If an rdf list node has additional triples, those triples are lost when it gets formatted.

With this commit, TurtleFormatter.isListNode(node) returns false if the node has other properties than rdf:first and rdf:rest.

Fixes #41 