### PR TITLE
Fix formatting empty lists

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,2 +1,3 @@
 Andreas Textor <mail@atextor.de>
 Florian Kleedorfer <florian.kleedorfer@austria.fm>
+Bogdan Toma <external.bogdan.toma@bosch.com>

--- a/src/main/java/de/atextor/turtle/formatter/TurtleFormatter.java
+++ b/src/main/java/de/atextor/turtle/formatter/TurtleFormatter.java
@@ -489,9 +489,16 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
             return writeList( resource, state );
         }
         if ( resource.isURIResource() ) {
+            if(resource.equals( RDF.nil )) {
+                return writeNil(resource, state);
+            }
             return writeUriResource( resource, state );
         }
         return writeAnonymousResource( resource, state );
+    }
+
+    private State writeNil(Resource resource, State state) {
+        return state.write( "( )");
     }
 
     private State writeList( final Resource resource, final State state ) {

--- a/src/main/java/de/atextor/turtle/formatter/TurtleFormatter.java
+++ b/src/main/java/de/atextor/turtle/formatter/TurtleFormatter.java
@@ -471,6 +471,9 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
         if ( !node.isResource() ) {
             return false;
         }
+        if( node.equals( RDF.nil ) ) {
+            return true;
+        }
         final boolean listNodeHasAdditionalTriples = state.model.listStatements( node.asResource(), null, (RDFNode) null )
             .toList()
             .stream()
@@ -489,16 +492,9 @@ public class TurtleFormatter implements Function<Model, String>, BiConsumer<Mode
             return writeList( resource, state );
         }
         if ( resource.isURIResource() ) {
-            if(resource.equals( RDF.nil )) {
-                return writeNil(resource, state);
-            }
             return writeUriResource( resource, state );
         }
         return writeAnonymousResource( resource, state );
-    }
-
-    private State writeNil(Resource resource, State state) {
-        return state.write( "( )");
     }
 
     private State writeList( final Resource resource, final State state ) {

--- a/src/test/java/de/atextor/turtle/formatter/TurtleFormatterTest.java
+++ b/src/test/java/de/atextor/turtle/formatter/TurtleFormatterTest.java
@@ -1187,6 +1187,48 @@ public class TurtleFormatterTest {
         assertThat(result.trim()).isEqualTo(expected);
     }
 
+    @Test
+    public void testEmptyList() {
+        var content =   """
+           @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+           @prefix : <http://example.com/ns#> .
+           :aThing a :element;
+            :has ();
+            :hasNil rdf:nil;
+            :numbers (1 2 3 );
+            :tests  ();
+            :hasList  [
+                 a :SomeListClass ;
+                 a rdf:List ;
+                 :numbersAgain ();
+                 :comment "a very special list";
+                 rdf:first 1 ;
+                 rdf:rest ( 2 3 4 )
+            ].
+           """;
+
+        final String expected = """
+              @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+              @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+              @prefix : <http://example.com/ns#> .
+ 
+              :aThing a :element ;
+                :has ( ) ;
+                :hasList [
+                  a :SomeListClass, rdf:List ;
+                  :comment "a very special list" ;
+                  :numbersAgain ( ) ;
+                  rdf:first 1 ;
+                  rdf:rest ( 2 3 4 ) ;
+                ] ;
+                :hasNil ( ) ;
+                :numbers ( 1 2 3 ) ;
+                :tests ( ) .""";
+        final FormattingStyle style = FormattingStyle.DEFAULT;
+        final TurtleFormatter formatter = new TurtleFormatter(style);
+        final String result = formatter.applyToContent(content);
+        assertThat(result.trim()).isEqualTo(expected);
+    }
 
 
     private Model modelFromString( final String content ) {


### PR DESCRIPTION
Fixing formatting empty list () which results into rdf:nil

```
:aThing a :element ;
   :has rdf:nil .
```
Fix #45 